### PR TITLE
[FIX] Change MSApplicationMetadata to BCSketchInfo.shared()

### DIFF
--- a/SketchAutoTranslate.sketchplugin/Contents/Sketch/common.js
+++ b/SketchAutoTranslate.sketchplugin/Contents/Sketch/common.js
@@ -2,7 +2,7 @@
 var pluginIdentifier = "design.sym.sketch.translate";
 var app              = NSApplication.sharedApplication();
 var googleApiKey     = getOption('apiKey', '');
-var sketchVersion    = MSApplicationMetadata.metadata().appVersion;
+var sketchVersion    = BCSketchInfo.shared().metadata().appVersion;
 
 var fontSizeLarge = 13
 var fontSizeSmall = 11;

--- a/SketchAutoTranslate.sketchplugin/Contents/Sketch/translator.js
+++ b/SketchAutoTranslate.sketchplugin/Contents/Sketch/translator.js
@@ -180,7 +180,7 @@ Translator.prototype.translatePage = function (context) {
 
         artboard = artboards[i];
 
-        var sketchVersion = MSApplicationMetadata.metadata().appVersion;
+        var sketchVersion = BCSketchInfo.shared().metadata().appVersion;
         ( sketchVersion > 45) ? artboard.select_byExpandingSelection(true, false) : artboard.select_byExtendingSelection(true, false);
 
         var symbolInstances = selectLayersOfTypeInContainer(context.document, "MSSymbolInstance", artboard);
@@ -228,7 +228,7 @@ Translator.prototype.translateDocument = function (context) {
     
             artboard = artboards[i];
     
-            var sketchVersion = MSApplicationMetadata.metadata().appVersion;
+            var sketchVersion = BCSketchInfo.shared().metadata().appVersion;
             ( sketchVersion > 45) ? artboard.select_byExpandingSelection(true, false) : artboard.select_byExtendingSelection(true, false);
     
             var symbolInstances = selectLayersOfTypeInContainer(context.document, "MSSymbolInstance", artboard);


### PR DESCRIPTION
The current plugin version throws MSApplicationMetadata exception in console and is not able to open the set API key window.

I replaced MSApplicationMetadata with BCSketchInfo.shared() and it's working again. I was able to auto translate a text selection, but I don't know if it's working for the entire document.